### PR TITLE
refactor(product_type): extract Product_Type model into dojo/product_type/ [Phase 1, 1/5]

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -758,75 +758,7 @@ class FileUpload(models.Model):
             raise ValidationError(msg)
 
 
-class Product_Type(BaseModel):
-
-    """
-    Product types represent the top level model, these can be business unit divisions, different offices or locations, development teams, or any other logical way of distinguishing "types" of products.
-    `
-       Examples:
-         * IAM Team
-         * Internal / 3rd Party
-         * Main company / Acquisition
-         * San Francisco / New York offices
-    """
-
-    name = models.CharField(max_length=255, unique=True)
-    description = models.CharField(max_length=4000, null=True, blank=True)
-    critical_product = models.BooleanField(default=False)
-    key_product = models.BooleanField(default=False)
-    authorized_users = models.ManyToManyField(Dojo_User, related_name="authorized_product_types", blank=True)
-
-    class Meta:
-        ordering = ("name",)
-
-    def __str__(self):
-        return self.name
-
-    def get_absolute_url(self):
-        return reverse("product_type", args=[str(self.id)])
-
-    def get_breadcrumbs(self):
-        return [{"title": str(self),
-               "url": reverse("edit_product_type", args=(self.id,))}]
-
-    @cached_property
-    def critical_present(self):
-        c_findings = Finding.objects.filter(
-            test__engagement__product__prod_type=self, severity="Critical")
-        if c_findings.count() > 0:
-            return True
-        return None
-
-    @cached_property
-    def high_present(self):
-        c_findings = Finding.objects.filter(
-            test__engagement__product__prod_type=self, severity="High")
-        if c_findings.count() > 0:
-            return True
-        return None
-
-    @cached_property
-    def calc_health(self):
-        h_findings = Finding.objects.filter(
-            test__engagement__product__prod_type=self, severity="High")
-        c_findings = Finding.objects.filter(
-            test__engagement__product__prod_type=self, severity="Critical")
-        health = 100
-        if c_findings.count() > 0:
-            health = 40
-            health -= ((c_findings.count() - 1) * 5)
-        if h_findings.count() > 0:
-            if health == 100:
-                health = 60
-            health -= ((h_findings.count() - 1) * 2)
-        if health < 5:
-            return 5
-        return health
-
-    # only used by bulk risk acceptance api
-    @property
-    def unaccepted_open_findings(self):
-        return Finding.objects.filter(risk_accepted=False, active=True, duplicate=False, test__engagement__product__prod_type=self)
+from dojo.product_type.models import Product_Type  # noqa: E402 -- re-export; mid-file as Product FK uses it below
 
 
 class Product_Line(models.Model):
@@ -4432,7 +4364,6 @@ admin.site.register(Endpoint_Params)
 admin.site.register(Endpoint_Status)
 admin.site.register(Endpoint)
 admin.site.register(Product)
-admin.site.register(Product_Type)
 admin.site.register(UserContactInfo)
 admin.site.register(Notes)
 admin.site.register(Note_Type)

--- a/dojo/product_type/__init__.py
+++ b/dojo/product_type/__init__.py
@@ -1,0 +1,1 @@
+import dojo.product_type.admin  # noqa: F401

--- a/dojo/product_type/admin.py
+++ b/dojo/product_type/admin.py
@@ -1,0 +1,9 @@
+from django.contrib import admin
+
+from dojo.product_type.models import Product_Type
+
+
+@admin.register(Product_Type)
+class Product_TypeAdmin(admin.ModelAdmin):
+
+    """Admin support for the Product_Type model."""

--- a/dojo/product_type/models.py
+++ b/dojo/product_type/models.py
@@ -1,0 +1,80 @@
+from django.db import models
+from django.urls import reverse
+from django.utils.functional import cached_property
+
+from dojo.base_models.base import BaseModel
+
+
+class Product_Type(BaseModel):
+
+    """
+    Product types represent the top level model, these can be business unit divisions, different offices or locations, development teams, or any other logical way of distinguishing "types" of products.
+    `
+       Examples:
+         * IAM Team
+         * Internal / 3rd Party
+         * Main company / Acquisition
+         * San Francisco / New York offices
+    """
+
+    name = models.CharField(max_length=255, unique=True)
+    description = models.CharField(max_length=4000, null=True, blank=True)
+    critical_product = models.BooleanField(default=False)
+    key_product = models.BooleanField(default=False)
+    authorized_users = models.ManyToManyField("dojo.Dojo_User", related_name="authorized_product_types", blank=True)
+
+    class Meta:
+        ordering = ("name",)
+
+    def __str__(self):
+        return self.name
+
+    def get_absolute_url(self):
+        return reverse("product_type", args=[str(self.id)])
+
+    def get_breadcrumbs(self):
+        return [{"title": str(self),
+               "url": reverse("edit_product_type", args=(self.id,))}]
+
+    @cached_property
+    def critical_present(self):
+        from dojo.models import Finding  # noqa: PLC0415 -- lazy import, avoids circular dependency
+        c_findings = Finding.objects.filter(
+            test__engagement__product__prod_type=self, severity="Critical")
+        if c_findings.count() > 0:
+            return True
+        return None
+
+    @cached_property
+    def high_present(self):
+        from dojo.models import Finding  # noqa: PLC0415 -- lazy import, avoids circular dependency
+        c_findings = Finding.objects.filter(
+            test__engagement__product__prod_type=self, severity="High")
+        if c_findings.count() > 0:
+            return True
+        return None
+
+    @cached_property
+    def calc_health(self):
+        from dojo.models import Finding  # noqa: PLC0415 -- lazy import, avoids circular dependency
+        h_findings = Finding.objects.filter(
+            test__engagement__product__prod_type=self, severity="High")
+        c_findings = Finding.objects.filter(
+            test__engagement__product__prod_type=self, severity="Critical")
+        health = 100
+        if c_findings.count() > 0:
+            health = 40
+            health -= ((c_findings.count() - 1) * 5)
+        if h_findings.count() > 0:
+            if health == 100:
+                health = 60
+            health -= ((h_findings.count() - 1) * 2)
+        if health < 5:
+            return 5
+        return health
+
+    # only used by bulk risk acceptance api
+    @property
+    def unaccepted_open_findings(self):
+        from dojo.models import Finding  # noqa: PLC0415 -- lazy import, avoids circular dependency
+        return Finding.objects.filter(risk_accepted=False, active=True, duplicate=False, test__engagement__product__prod_type=self)


### PR DESCRIPTION
## Summary

Phase 1 of the module reorganization described in `AGENTS.md` — extract the `Product_Type` model into a self-contained `dojo/product_type/` module matching the `dojo/url/` reference pattern.

- Move `Product_Type` from `dojo/models.py` into `dojo/product_type/models.py`.
- Add `dojo/product_type/admin.py` with the `@admin.register(Product_Type)` registration (removed from `dojo/models.py`).
- Set `dojo/product_type/__init__.py` to import the admin module (triggers model discovery, same chain as `dojo/url/`).
- Leave a backward-compatible re-export in `dojo/models.py`, so all existing `from dojo.models import Product_Type` consumers keep working unchanged.
- Downward references to `Finding` use lazy imports inside method bodies to avoid circular imports.
- No migration change — `app_label` stays `dojo`.

First branch of a stacked series (product_type → test → engagement → product → finding).
